### PR TITLE
Use an appwide theme at a higher api level

### DIFF
--- a/OpenTreeMap/res/layout/plot_field_edit_row.xml
+++ b/OpenTreeMap/res/layout/plot_field_edit_row.xml
@@ -37,8 +37,9 @@
              android:layout_width="wrap_content"
              android:layout_height="match_parent"
              android:layout_alignParentLeft="true"
-             android:textColor="@color/text_light" 
-             android:layout_toLeftOf="@id/field_unit">
+             android:layout_toLeftOf="@id/field_unit"
+             android:textColor="@color/text_dark" >
+
          </EditText>
 
          </RelativeLayout>

--- a/templates/AndroidManifest.xml
+++ b/templates/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:protectionLevel="signature" />
 
     <uses-sdk
-        android:minSdkVersion="8"
+        android:minSdkVersion="11"
         android:targetSdkVersion="16" />
 
     <uses-permission android:name="%(packagename)s.permission.MAPS_RECEIVE" />
@@ -27,6 +27,7 @@
     <application
         android:name="App"
         android:icon="@drawable/app_icon"
+        android:theme="@android:style/Theme.Holo.Light"
         android:label="@string/app_name" >
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"


### PR DESCRIPTION
Holo is only valid at API level 11 and above, which I now target.
This gives a light background with dark text on inputs.  Future
commits will consolidate the theme styles and provide a fallback
for lower SDK levels.
Fixes #54 
