### PR TITLE
Fix basemap switcher

### DIFF
--- a/OpenTreeMap/src/org/azavea/otm/ui/MainMapActivity.java
+++ b/OpenTreeMap/src/org/azavea/otm/ui/MainMapActivity.java
@@ -215,7 +215,7 @@ public class MainMapActivity extends Fragment {
                     START_POS = App.getCurrentInstance().getStartPos();
                     bindActionToLocationSearchBar(view);
                     filterDisplay = (TextView) view.findViewById(R.id.filterDisplay);
-                    setUpMapIfNeeded();
+                    setUpMapIfNeeded(view);
                     plotPopup = (RelativeLayout) view.findViewById(R.id.plotPopup);
                     setPopupViews(view);
                     clearTileCache();
@@ -248,7 +248,7 @@ public class MainMapActivity extends Fragment {
         MapHelper.checkGooglePlay(getActivity());
         mapView.onResume();
         if (App.getAppInstance().getCurrentInstance() != null) {
-            setUpMapIfNeeded();
+            setUpMapIfNeeded(getView());
             setTreeAddMode(CANCEL);
             clearTileCache();
 
@@ -353,14 +353,14 @@ public class MainMapActivity extends Fragment {
      * paused), {@link #onCreate(Bundle)} may not be called again so we should call this method in
      * {@link #onResume()} to guarantee that it will be called.
      */
-    private void setUpMapIfNeeded() {
+    private void setUpMapIfNeeded(View view) {
         // Do a null check to confirm that we have not already instantiated the map.
         if (mMap == null) {
             // Try to obtain the map from the MapView.
             mMap = mapView.getMap();
             // Check if we were successful in obtaining the map.
             if (mMap != null) {
-                setUpMap();
+                setUpMap(view);
             } else {
                 Toast.makeText(getActivity(), "Google Play store support is required to run this app.", Toast.LENGTH_LONG).show();
                 Log.e(App.LOG_TAG, "Map was null!");
@@ -368,7 +368,7 @@ public class MainMapActivity extends Fragment {
         }
     }
 
-    private void setUpMap() {
+    private void setUpMap(View view) {
         SharedPreferences prefs = App.getSharedPreferences();
         int startingZoomLevel = Integer.parseInt(prefs.getString("starting_zoom_level", "12"));
         String baseTileUrl = prefs.getString("tiler_url", null);
@@ -397,11 +397,12 @@ public class MainMapActivity extends Fragment {
 
             // Set up the default click listener
             mMap.setOnMapClickListener(showPopupMapClickListener);
+            SegmentedButton buttons = (SegmentedButton)view.findViewById(R.id.basemap_controls);
 
-            setTreeAddMode(CANCEL);
-            setUpBasemapControls();
+            MapHelper.setUpBasemapControls(buttons, mMap);
         } catch (Exception e) {
-            // TODO: Toast
+            Log.e("BASEMAP_SETUP", "Error Setting Up Basemap: ", e);
+            Toast.makeText(getActivity(), "Error Setting Up Basemap", Toast.LENGTH_LONG).show();
         }
     }
 
@@ -728,32 +729,6 @@ public class MainMapActivity extends Fragment {
         } else {
             moveMapAndFinishGeocode(pos);
         }
-    }
-
-    public void setUpBasemapControls() {
-        // Create the segmented buttons
-        SegmentedButton buttons = (SegmentedButton) getActivity().findViewById(R.id.basemap_controls);
-        buttons.clearButtons();
-
-        ArrayList<String> buttonNames = new ArrayList<>();
-        buttonNames.add("map");
-        buttonNames.add("satellite");
-        buttonNames.add("hybrid");
-        buttons.addButtons(buttonNames.toArray(new String[buttonNames.size()]));
-
-        buttons.setOnClickListener((int index) -> {
-            switch (index) {
-                case 0:
-                    mMap.setMapType(GoogleMap.MAP_TYPE_NORMAL);
-                    break;
-                case 1:
-                    mMap.setMapType(GoogleMap.MAP_TYPE_SATELLITE);
-                    break;
-                case 2:
-                    mMap.setMapType(GoogleMap.MAP_TYPE_HYBRID);
-                    break;
-            }
-        });
     }
 
     private void setupLocationUpdating(Context applicationContext) {

--- a/OpenTreeMap/src/org/azavea/otm/ui/MapHelper.java
+++ b/OpenTreeMap/src/org/azavea/otm/ui/MapHelper.java
@@ -1,22 +1,40 @@
 package org.azavea.otm.ui;
 
 import org.azavea.otm.App;
+import org.azavea.otm.R;
 import org.azavea.otm.data.Plot;
 
 
+import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
 import android.graphics.BitmapFactory;
 import android.support.v4.app.FragmentActivity;
 import android.util.Log;
+import android.view.View;
 import android.view.Window;
 import android.widget.ImageView;
 import android.widget.Toast;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.maps.GoogleMap;
+import com.joelapenna.foursquared.widget.SegmentedButton;
 import com.loopj.android.http.BinaryHttpResponseHandler;
 
 public class MapHelper {
+
+    public static void setUpBasemapControls(SegmentedButton buttons, GoogleMap mMap) {
+        final String[] mapLabels = {"map", "satellite", "hybrid"};
+        final int[] mapTypes = {GoogleMap.MAP_TYPE_NORMAL,
+                                GoogleMap.MAP_TYPE_SATELLITE,
+                                GoogleMap.MAP_TYPE_HYBRID};
+
+        // match the clicked index of mapLabels to the element of mapTypes
+        buttons.clearButtons();
+        buttons.addButtons(mapLabels);
+        buttons.setOnClickListener((int index) -> { mMap.setMapType(mapTypes[index]); });
+    }
 
     public static void checkGooglePlay(FragmentActivity activity) {
         int googlePlayStatus = GooglePlayServicesUtil.isGooglePlayServicesAvailable(activity);

--- a/OpenTreeMap/src/org/azavea/otm/ui/TreeMove.java
+++ b/OpenTreeMap/src/org/azavea/otm/ui/TreeMove.java
@@ -22,7 +22,8 @@ public class TreeMove extends TreeDisplay {
         setUpMapIfNeeded();
         showPositionOnMap();
         plotMarker.setDraggable(true);
-        setUpBasemapControls();
+        SegmentedButton buttons = (SegmentedButton)findViewById(R.id.basemap_controls);
+        MapHelper.setUpBasemapControls(buttons, mMap);
     }
 
     public void submitTreeMove(View view) {
@@ -39,31 +40,5 @@ public class TreeMove extends TreeDisplay {
         editPlot.putExtra("plot", plot.getData().toString());
         setResult(RESULT_OK, editPlot);
         finish();
-    }
-
-    public void setUpBasemapControls() {
-        // Create the segmented buttons
-        SegmentedButton buttons = (SegmentedButton) findViewById(R.id.basemap_controls);
-        buttons.clearButtons();
-
-        ArrayList<String> buttonNames = new ArrayList<>();
-        buttonNames.add("map");
-        buttonNames.add("satellite");
-        buttonNames.add("hybrid");
-        buttons.addButtons(buttonNames.toArray(new String[buttonNames.size()]));
-
-        buttons.setOnClickListener((int index) -> {
-            switch (index) {
-                case 0:
-                    mMap.setMapType(GoogleMap.MAP_TYPE_NORMAL);
-                    break;
-                case 1:
-                    mMap.setMapType(GoogleMap.MAP_TYPE_SATELLITE);
-                    break;
-                case 2:
-                    mMap.setMapType(GoogleMap.MAP_TYPE_HYBRID);
-                    break;
-            }
-        });
     }
 }


### PR DESCRIPTION
fixes #114 on github

The basemap switcher was not loading because it was loading after a line
of code that was producing a NullPointerException, both of which were
contained in a silently failing try-catch block. So when the earlier
code failed, the basemap switcher was not initialized.

This commit does the following:
Remove the line of code that was crashing entirely - it turned out it
did not need to be fixed, it was not necessary.
Add a log message and toast for when this try-catch block fails, so it
can be debugged more easily.
Refactor basemap initialization out to a helper to be DRY.
