### PR TITLE
Use location of 0,0 in order to retrieve user instances when GPS is off

### DIFF
--- a/OpenTreeMap/src/org/azavea/otm/adapters/InstanceInfoArrayAdapter.java
+++ b/OpenTreeMap/src/org/azavea/otm/adapters/InstanceInfoArrayAdapter.java
@@ -48,10 +48,10 @@ public class InstanceInfoArrayAdapter extends LinkedHashMapAdapter<InstanceInfo>
             holder = (InstanceHolder) convertView.getTag();
         }
         // gather data from instanceInfo in scope to use in subviews
-        Location instanceLocation = new Location(userLocation);
+        Location instanceLocation = new Location("");
         instanceLocation.setLatitude(element.getLat());
         instanceLocation.setLongitude(element.getLon());
-        String distance = distanceToString(userLocation.distanceTo(instanceLocation), true) + " away";
+        String distance = userLocation == null ? "" : distanceToString(userLocation.distanceTo(instanceLocation), true) + " away";
 
         // populate subviews for the instance in scope
         holder.textView.setText(element.getName());


### PR DESCRIPTION
This is a stopgap measure.  The ideal solution is to create a new API
endpoint that does not use location at all, and only returns user
instances, preferably sorted by something other than distance.

Fixes #134
