### PR TITLE
Fix app crash when attempting to edit a tree with no date planted value

### DIFF
--- a/OpenTreeMap/src/org/azavea/otm/Field.java
+++ b/OpenTreeMap/src/org/azavea/otm/Field.java
@@ -319,8 +319,8 @@ public class Field {
     }
 
     private void setupDateField(final Button choiceButton, final Object value, final Context context) {
-        String timestamp = (String) value;
         if (!JSONObject.NULL.equals(value)) {
+            String timestamp = (String) value;
             final String formattedDate = formatTimestampForDisplay(timestamp);
             choiceButton.setText(formattedDate);
             choiceButton.setTag(R.id.choice_button_value_tag, timestamp);


### PR DESCRIPTION
Caused by ClassCastException, we were trying to cast to a String before
checking if the value was in fact a JSONObject.NULL value

Fixes #141
