### PR TITLE
Fix occasional build errors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,11 @@ buildscript {
         classpath 'com.android.tools.build:gradle:0.12.+'
         classpath 'me.tatarka:gradle-retrolambda:2.1.+'
     }
+    // Work around bug with gradle-retrolambda and newest version of the android gradle plugin
+    configurations {
+        compile.exclude module: 'support-annotations'
+    }
+
 }
 
 allprojects {


### PR DESCRIPTION
We were occasionally receiving non-fatal errors during the build, which
seems to be an issue with gradle-retrolambda in combination with the most
recent version of the android gradle plugin.

The issue is being tracked in the gradle-retrolambda project here:
https://github.com/evant/gradle-retrolambda/issues/27

In the mean time, this was suggested as a workaround.  We don't rely on
support-annotations directly (they're a transitive dependency), so I
believe it should be safe to exclude them for now.
