### PR TITLE
Don't create a tree unless tree fields are edited

### DIFF
--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeEditDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeEditDisplay.java
@@ -271,7 +271,7 @@ public class TreeEditDisplay extends TreeDisplay {
 
             // check if we are adding a new tree or editing an existing one.
             if (addMode()) {
-                rg.addTree(plot, responseHandler);
+                rg.addPlot(plot, responseHandler);
             } else {
                 rg.updatePlot(plot.getId(), plot, responseHandler);
             }


### PR DESCRIPTION
Only send up plot and tree JSON when saving plots, and don't send up tree
JSON unless the plot has a tree or tree fields were edited.

Fixes #164
