### PR TITLE
Fix Travis CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,29 @@
 language: android
 jdk: oraclejdk8
+sudo: false
 env:
+  global:
+    - GRADLE_OPTS="-Xmx512m"
   matrix:
-    - ANDROID_TARGET=android-19 ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-21 ANDROID_ABI=armeabi-v7a
 
 android:
   components:
-    - build-tools-19.1.0
+    - build-tools-21.1.1
     - platform-tools
-    - android-19
-    - sys-img-armeabi-v7a-android-19
-    - addon-google_apis-google-19
+    - android-21
+    - sys-img-armeabi-v7a-android-21
+    - addon-google_apis-google-21
     - extra-android-m2repository
     - extra-google-m2repository
     - extra-android-support
   licenses:
-    - android-sdk-license-bcbbd656
-    - android-sdk-license-5be876d5
-    - android-sdk-license-598b93a6
-    - 'android-*'
+    - 'android-sdk-license-.*'
     - '.*intel.+'
 
 before_install:
   - export "JAVA8_HOME=/usr/lib/jvm/java-8-oracle"
-  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI --skin WVGA800
   - sleep 5
   - emulator -avd test -no-skin -no-audio -no-window &
   - sleep 30

--- a/OpenTreeMap/src/androidTest/AndroidManifest.xml
+++ b/OpenTreeMap/src/androidTest/AndroidManifest.xml
@@ -6,13 +6,13 @@
     android:versionName="1.0">
 
     <uses-sdk android:minSdkVersion="8"
-        	  android:targetSdkVersion="8" />
+              android:targetSdkVersion="8" />
     <uses-permission android:name="android.permission.INTERNET" />
-    
+
     <instrumentation
         tools:replace="android:targetPackage"
         android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="org.azavea.otm" />
+        android:targetPackage="org.azavea.otm.test" />
 
     <application
         android:label="@string/app_name" >


### PR DESCRIPTION
There were a couple of issues at play here.

Our builds were being killed for using up too much memory.
Switching to the new container based CI infrastructure, adding GRADLE_OPTS
and passing a skin option when creating the emulator fixed those.

We also had issues building and running the tests.
Fixing the Android SDK dependencies to be at API 21 and fixing the
targetPackage in the test AndroidManifest.xml fixed those issues.

Connects to #213