### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 
 android:
   components:
-    - build-tools-21.1.1
+    - build-tools-21.1.2
     - platform-tools
     - android-21
     - sys-img-armeabi-v7a-android-21
@@ -22,6 +22,7 @@ android:
     - '.*intel.+'
 
 before_install:
+  - cp ci/AndroidManifest.xml OpenTreeMapSkinned/AndroidManifest.xml
   - export "JAVA8_HOME=/usr/lib/jvm/java-8-oracle"
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI --skin WVGA800
   - sleep 5

--- a/ci/AndroidManifest.xml
+++ b/ci/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.azavea.otm.citest"
+    android:versionCode="0"
+    android:versionName="0" >
+
+    <uses-sdk
+        android:minSdkVersion="10"
+        android:targetSdkVersion="22" />
+
+</manifest>


### PR DESCRIPTION
 - We updated to a newer version of the build tools
 - The new gradle version seems to want an AndroidManifest.xml for the
   OpenTreeMapSkinned project even though we only test the library project