### PR TITLE
Fix exception when attempting to display trees with missing diameters

### DIFF
--- a/OpenTreeMap/build.gradle
+++ b/OpenTreeMap/build.gradle
@@ -15,12 +15,8 @@ dependencies {
     // You must install or update the Support Repository through the SDK manager to use these dependencies
     compile 'com.android.support:support-v4:19.1.+'
     compile 'com.android.support:appcompat-v7:19.1.+'
+    compile 'com.android.support:support-annotations:19.1.+'
     compile 'com.google.android.gms:play-services:6.1.71'
-}
-
-// Work around bug with gradle-retrolambda and newest version of the android gradle plugin
-configurations {
-    compile.exclude module: 'support-annotations'
 }
 
 android {

--- a/OpenTreeMap/src/main/java/org/azavea/lists/NearbyList.java
+++ b/OpenTreeMap/src/main/java/org/azavea/lists/NearbyList.java
@@ -207,11 +207,11 @@ public class NearbyList implements InfoList {
         try {
             Double dbh = p.getTree().getDiameter();
 
-            if (dbhField != null && dbh > 0d) {
+            if (dbhField != null && dbh != null && dbh > 0d) {
                 diameter = Double.toString(dbh) + " " + dbhField.unitText;
             }
-        } catch (Exception e) {
-            Logger.error("Unable to get tree diameter", e);
+        } catch (JSONException e) {
+            Logger.error("Unable to get tree diameter field", e);
         }
         return diameter;
     }

--- a/OpenTreeMap/src/main/java/org/azavea/otm/data/Model.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/data/Model.java
@@ -23,7 +23,7 @@ public abstract class Model {
         }
     }
 
-    protected double getDoubleOrDefault(String key, Double defaultValue) throws JSONException {
+    protected Double getDoubleOrDefault(String key, Double defaultValue) throws JSONException {
         if (data.isNull(key)) {
             return defaultValue;
         } else {

--- a/OpenTreeMap/src/main/java/org/azavea/otm/data/Tree.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/data/Tree.java
@@ -1,5 +1,7 @@
 package org.azavea.otm.data;
 
+import android.support.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -24,22 +26,9 @@ public class Tree extends Model {
         data.put("id", id);
     }
 
-    public double getDiameter() throws JSONException {
-        return getDiameter(false);
-    }
-
-    public double getDiameter(boolean getCurrentOnly) throws JSONException {
-        if (getCurrentOnly) {
-            return getDoubleOrDefault("tree.diameter", 0d);
-        }
-
-        // Use the field value, which could be a recent pending value
-        Object value = plot.getValueForKey("tree.diameter");
-        if (value != null) {
-            return Double.parseDouble(value.toString());
-        } else {
-            return 0d;
-        }
+    @Nullable
+    public Double getDiameter() throws JSONException {
+        return getDoubleOrDefault("tree.diameter", null);
     }
 
     public String getDateRemoved() throws JSONException {


### PR DESCRIPTION
The `getDiameter` function was not handling null values properly. I changed
the method signature to return a boxed (and thus nullable) double, and
added the `@Nullable` annotation to expose any usage of the value where we
were not checking for null values.

Connects to #203