### PR TITLE
Disallow use of insecure TLS/SSL cipher prototocols

### DIFF
--- a/OpenTreeMap/build.gradle
+++ b/OpenTreeMap/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'com.atlassian.fugue:fugue:2.1.0'
     compile 'com.loopj.android:android-async-http:1.4.5'
+    compile 'info.guardianproject.netcipher:netcipher:1.2'
 
     // You must install or update the Support Repository through the SDK manager to use these dependencies
     compile 'com.android.support:support-v4:19.1.+'

--- a/OpenTreeMap/src/main/java/org/azavea/map/TMSTileProvider.java
+++ b/OpenTreeMap/src/main/java/org/azavea/map/TMSTileProvider.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import info.guardianproject.netcipher.NetCipher;
+
 public class TMSTileProvider implements TileProvider {
     private final static int TILE_HEIGHT = 256;
     private final static int TILE_WIDTH = 256;
@@ -76,7 +78,8 @@ public class TMSTileProvider implements TileProvider {
         InputStream imageStream = null;
         Bitmap inputImage;
         try {
-            imageStream = this.getTileUrl(x, y, zoom).openStream();
+            URL url = getTileUrl(x, y, zoom);
+            imageStream = NetCipher.getHttpURLConnection(url).getInputStream();
             inputImage = BitmapFactory.decodeStream(imageStream);
         } catch (IOException e) {
             Logger.error("Could not convert tiler results to Bitmap", e);

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'me.tatarka:gradle-retrolambda:2.4.1'
     }
 }
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
         // For fugue
         maven {
             url 'https://maven.atlassian.com/content/repositories/atlassian-public'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 15 11:31:46 EST 2015
+#Fri Apr 08 11:05:17 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
Uses https://github.com/guardianproject/NetCipher to limit our SSL cipher
suite to known secure implementations, avoiding issues that have been
reported via Rollbar of inability to access tiles due to clients
attempting to download them via SSLv3, which is insecure and not supported
by AWS CloudFront.

Also upgrades our Gradle version to 2.0, which is required for Android Studio 2.0+

Connects to #259