### PR TITLE
Fix setting tree position by long-pressing and dragging tree marker

### DIFF
--- a/OpenTreeMap/src/main/java/org/azavea/helpers/GoogleMapsListeners.java
+++ b/OpenTreeMap/src/main/java/org/azavea/helpers/GoogleMapsListeners.java
@@ -1,0 +1,27 @@
+package org.azavea.helpers;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.Marker;
+
+public class GoogleMapsListeners {
+    // We need to set a listener for marker drag, or markers will not give the correct position
+    // when we later call marker.getPosition()
+    // Note that we do not have to actually *do* anything in our listener
+    public static class NoopDragListener implements GoogleMap.OnMarkerDragListener {
+
+        @Override
+        public void onMarkerDragStart(Marker marker) {
+
+        }
+
+        @Override
+        public void onMarkerDrag(Marker marker) {
+
+        }
+
+        @Override
+        public void onMarkerDragEnd(Marker marker) {
+
+        }
+    }
+}

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/MainMapFragment.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/MainMapFragment.java
@@ -43,6 +43,7 @@ import com.loopj.android.http.JsonHttpResponseHandler;
 import com.loopj.android.http.RequestParams;
 
 import org.apache.http.Header;
+import org.azavea.helpers.GoogleMapsListeners;
 import org.azavea.helpers.Logger;
 import org.azavea.map.FilterableTMSTileProvider;
 import org.azavea.map.TMSTileProvider;
@@ -390,6 +391,7 @@ public class MainMapFragment extends Fragment {
         mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(START_POS, startingZoomLevel));
         mMap.getUiSettings().setZoomControlsEnabled(false);
         mMap.setMyLocationEnabled(true);
+        mMap.setOnMarkerDragListener(new GoogleMapsListeners.NoopDragListener());
 
         try {
             TMSTileProvider boundaryTileProvider = new TMSTileProvider(baseTileUrl, boundaryFeature);

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeDisplay.java
@@ -16,6 +16,7 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 
+import org.azavea.helpers.GoogleMapsListeners;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.R;
 import org.azavea.otm.data.Geometry;
@@ -99,6 +100,7 @@ public class TreeDisplay extends UpEnabledActionBarActivity {
         mUiSettings.setZoomGesturesEnabled(false);
         mUiSettings.setTiltGesturesEnabled(false);
         mUiSettings.setRotateGesturesEnabled(false);
+        mMap.setOnMarkerDragListener(new GoogleMapsListeners.NoopDragListener());
     }
 
     protected void setText(int resourceId, String text) {


### PR DESCRIPTION
We need to set a marker drag listener on the map object (though we don't need to do anything in it) in order for `marker.getPosition()` to return correct results.

Connects to #265