### PR TITLE
Fix setting the species during the add tree process.

### DIFF
--- a/OpenTreeMap/src/main/java/org/azavea/otm/fields/UDFCollectionFieldGroup.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/fields/UDFCollectionFieldGroup.java
@@ -99,6 +99,7 @@ public class UDFCollectionFieldGroup extends FieldGroup {
 
     @Override
     public void receiveActivityResult(int resultCode, Intent data, Activity activity) {
+        boolean shouldUpdate = false;
         for (String key : editableUdfDefinitions.keySet()) {
             if (data.getExtras().containsKey(key)) {
                 final String json = data.getStringExtra(key);
@@ -111,6 +112,8 @@ public class UDFCollectionFieldGroup extends FieldGroup {
                     Logger.error("Error parsing JSON passed as activity result", e);
                     continue;
                 }
+
+                shouldUpdate = true;
 
                 // The presence of a tag tells us if this is an edit to an existing field or an add
                 final UDFCollectionValueField field = new UDFCollectionValueField(udfDef, sortKey, value);
@@ -127,7 +130,9 @@ public class UDFCollectionFieldGroup extends FieldGroup {
                 }
             }
         }
-        rerenderEditFields(activity);
+        if (shouldUpdate) {
+            rerenderEditFields(activity);
+        }
     }
 
     @Override


### PR DESCRIPTION
For maps without stewardship fields, setting the species when adding a tree
was causing the app to crash, as it would attempt to update stewardship
fields after the species was set.

By tracking whether the stewardship fields need to be updated, we can avoid
this scenario.

Connects to #266