### PR TITLE
Allow searching in any part of the map name on the public maps list screen

### DIFF
--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/PublicInstanceListDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/PublicInstanceListDisplay.java
@@ -54,6 +54,7 @@ public class PublicInstanceListDisplay extends FilterableListDisplay<InstanceInf
                         PublicInstanceListDisplay.this, sectionedInstances,
                         R.layout.list_separator_row, R.id.separator,
                         R.layout.public_instance_element_row, R.id.text);
+                adapter.setFilterType(LinkedHashMapAdapter.FilterType.ANYWHERE);
                 renderList(adapter);
             }
 


### PR DESCRIPTION
Species and Map searching both share code paths, but I opted to have
species search continue to match on only the start of words, which is
what the website does.

Connects to #248