### PR TITLE
Update the Android-Async-Http library

### DIFF
--- a/OpenTreeMap/build.gradle
+++ b/OpenTreeMap/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile 'org.jdeferred:jdeferred-android-aar:1.2.1'
     compile 'com.google.guava:guava:18.0'
     compile 'com.atlassian.fugue:fugue:2.1.0'
-    compile 'com.loopj.android:android-async-http:1.4.5'
+    compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'info.guardianproject.netcipher:netcipher:1.2'
     compile 'com.rollbar:rollbar-android:0.1.3'
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/FilterManager.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/FilterManager.java
@@ -3,7 +3,6 @@ package org.azavea.otm;
 import android.os.Bundle;
 import android.os.Handler.Callback;
 import android.os.Message;
-import android.view.View;
 
 import com.atlassian.fugue.Either;
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/LoginManager.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/LoginManager.java
@@ -8,13 +8,14 @@ import android.os.Bundle;
 import android.os.Handler.Callback;
 import android.os.Message;
 
-import org.apache.http.client.HttpResponseException;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.data.User;
 import org.azavea.otm.rest.RequestGenerator;
 import org.azavea.otm.rest.handlers.RestHandler;
 import org.azavea.otm.ui.InstanceSwitcherActivity;
 import org.json.JSONException;
+
+import cz.msebera.android.httpclient.client.HttpResponseException;
 
 public class LoginManager {
     private static final String MESSAGE_KEY = "message";

--- a/OpenTreeMap/src/main/java/org/azavea/otm/fields/DateField.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/fields/DateField.java
@@ -1,21 +1,11 @@
 package org.azavea.otm.fields;
 
 import android.app.Activity;
-import android.app.DatePickerDialog;
-import android.content.Context;
 import android.widget.Button;
 
-import org.azavea.helpers.Logger;
-import org.azavea.otm.App;
 import org.azavea.otm.R;
 import org.azavea.otm.data.Model;
 import org.json.JSONObject;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
 
 import static org.azavea.helpers.DateButtonListener.formatTimestampForDisplay;
 import static org.azavea.helpers.DateButtonListener.getDateButtonListener;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/filters/BaseFilter.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/filters/BaseFilter.java
@@ -1,7 +1,6 @@
 package org.azavea.otm.filters;
 
 import android.app.Activity;
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/filters/DateRangeFilter.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/filters/DateRangeFilter.java
@@ -1,11 +1,8 @@
 package org.azavea.otm.filters;
 
 import android.app.Activity;
-import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.Button;
 import android.widget.TextView;
 
 import org.azavea.otm.R;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/map/FallbackGeocoder.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/map/FallbackGeocoder.java
@@ -13,7 +13,6 @@ import com.loopj.android.http.RequestParams;
 
 import org.azavea.helpers.Logger;
 import org.azavea.otm.data.InstanceInfo;
-import org.azavea.otm.data.InstanceInfo.InstanceExtent;
 import org.json.JSONObject;
 
 import java.io.IOException;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/rest/RequestSignature.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/rest/RequestSignature.java
@@ -5,8 +5,6 @@ import android.util.Base64;
 
 import com.loopj.android.http.RequestParams;
 
-import org.apache.http.Header;
-import org.apache.http.message.BasicHeader;
 import org.azavea.helpers.Logger;
 
 import java.io.UnsupportedEncodingException;
@@ -18,6 +16,9 @@ import java.util.Arrays;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+
+import cz.msebera.android.httpclient.Header;
+import cz.msebera.android.httpclient.message.BasicHeader;
 
 public class RequestSignature {
     private static final String HMAC_ALGORITHM = "HmacSHA256";

--- a/OpenTreeMap/src/main/java/org/azavea/otm/rest/RestClient.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/rest/RestClient.java
@@ -13,10 +13,6 @@ import com.loopj.android.http.BinaryHttpResponseHandler;
 import com.loopj.android.http.JsonHttpResponseHandler;
 import com.loopj.android.http.RequestParams;
 
-import org.apache.http.Header;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHeader;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;
 import org.azavea.otm.data.Model;
@@ -31,6 +27,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.TimeZone;
+
+import cz.msebera.android.httpclient.Header;
+import cz.msebera.android.httpclient.entity.ByteArrayEntity;
+import cz.msebera.android.httpclient.entity.StringEntity;
+import cz.msebera.android.httpclient.message.BasicHeader;
 
 // This class is designed to take care of the base-url
 // and otm api-key for REST requests

--- a/OpenTreeMap/src/main/java/org/azavea/otm/rest/handlers/ContainerRestHandler.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/rest/handlers/ContainerRestHandler.java
@@ -1,8 +1,9 @@
 package org.azavea.otm.rest.handlers;
 
-import org.apache.http.Header;
 import org.azavea.otm.data.ModelContainer;
 import org.json.JSONArray;
+
+import cz.msebera.android.httpclient.Header;
 
 public abstract class ContainerRestHandler<T extends ModelContainer<?>> extends LoggingJsonHttpResponseHandler {
     private T resultObject;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/rest/handlers/LoggingJsonHttpResponseHandler.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/rest/handlers/LoggingJsonHttpResponseHandler.java
@@ -2,9 +2,10 @@ package org.azavea.otm.rest.handlers;
 
 import com.loopj.android.http.JsonHttpResponseHandler;
 
-import org.apache.http.Header;
 import org.azavea.helpers.Logger;
 import org.json.JSONObject;
+
+import cz.msebera.android.httpclient.Header;
 
 public abstract class LoggingJsonHttpResponseHandler extends JsonHttpResponseHandler {
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/rest/handlers/RestHandler.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/rest/handlers/RestHandler.java
@@ -1,8 +1,9 @@
 package org.azavea.otm.rest.handlers;
 
-import org.apache.http.Header;
 import org.azavea.otm.data.Model;
 import org.json.JSONObject;
+
+import cz.msebera.android.httpclient.Header;
 
 public abstract class RestHandler<T extends Model> extends LoggingJsonHttpResponseHandler {
     public static final String SUCCESS_KEY = "success";

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/ChangePassword.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/ChangePassword.java
@@ -10,7 +10,6 @@ import android.widget.Toast;
 
 import com.loopj.android.http.JsonHttpResponseHandler;
 
-import org.apache.http.Header;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;
 import org.azavea.otm.LoginManager;
@@ -21,6 +20,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
+
+import cz.msebera.android.httpclient.Header;
 
 public class ChangePassword extends UpEnabledActionBarActivity {
     private String newPassword;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/FilterDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/FilterDisplay.java
@@ -6,12 +6,8 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.Button;
-import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Toast;
-import android.widget.ToggleButton;
 
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/InstanceSwitcherActivity.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/InstanceSwitcherActivity.java
@@ -18,7 +18,6 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.apache.http.Header;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;
 import org.azavea.otm.LoginManager;
@@ -36,6 +35,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+
+import cz.msebera.android.httpclient.Header;
 
 
 public class InstanceSwitcherActivity extends Activity {

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/LoginActivity.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/LoginActivity.java
@@ -10,7 +10,6 @@ import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
-import android.view.ViewGroup.LayoutParams;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.Toast;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/MainMapFragment.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/MainMapFragment.java
@@ -46,7 +46,6 @@ import com.loopj.android.http.BinaryHttpResponseHandler;
 import com.loopj.android.http.JsonHttpResponseHandler;
 import com.loopj.android.http.RequestParams;
 
-import org.apache.http.Header;
 import org.azavea.helpers.GoogleMapsListeners;
 import org.azavea.helpers.Logger;
 import org.azavea.map.FilterableTMSTileProvider;
@@ -54,7 +53,6 @@ import org.azavea.map.TMSTileProvider;
 import org.azavea.otm.App;
 import org.azavea.otm.R;
 import org.azavea.otm.data.Geometry;
-import org.azavea.otm.data.InstanceInfo;
 import org.azavea.otm.data.Plot;
 import org.azavea.otm.data.PlotContainer;
 import org.azavea.otm.map.FallbackGeocoder;
@@ -68,6 +66,8 @@ import org.json.JSONObject;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+
+import cz.msebera.android.httpclient.Header;
 
 public class MainMapFragment extends Fragment implements GoogleApiClient.ConnectionCallbacks {
     private static LatLng START_POS;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/MapHelper.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/MapHelper.java
@@ -15,12 +15,13 @@ import com.google.android.gms.maps.GoogleMap;
 import com.joelapenna.foursquared.widget.SegmentedButton;
 import com.loopj.android.http.BinaryHttpResponseHandler;
 
-import org.apache.http.Header;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;
 import org.azavea.otm.R;
 import org.azavea.otm.data.Plot;
 import org.json.JSONException;
+
+import cz.msebera.android.httpclient.Header;
 
 public class MapHelper {
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/OTMActionBarActivity.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/OTMActionBarActivity.java
@@ -1,6 +1,5 @@
 package org.azavea.otm.ui;
 
-import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 
 import org.azavea.otm.App;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/PendingItemDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/PendingItemDisplay.java
@@ -3,7 +3,6 @@ package org.azavea.otm.ui;
 import java.io.UnsupportedEncodingException;
 import java.util.Vector;
 
-import org.apache.http.Header;
 import org.azavea.otm.App;
 import org.azavea.otm.R;
 import org.azavea.otm.data.PendingEditDescription;
@@ -17,7 +16,6 @@ import org.json.JSONObject;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -26,6 +24,8 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.loopj.android.http.JsonHttpResponseHandler;
+
+import cz.msebera.android.httpclient.Header;
 
 public class PendingItemDisplay extends Activity {
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/PublicInstanceListDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/PublicInstanceListDisplay.java
@@ -5,7 +5,6 @@ import android.app.ProgressDialog;
 import android.os.Bundle;
 import android.widget.Toast;
 
-import org.apache.http.Header;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;
 import org.azavea.otm.R;
@@ -17,6 +16,8 @@ import org.json.JSONArray;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+
+import cz.msebera.android.httpclient.Header;
 
 public class PublicInstanceListDisplay extends FilterableListDisplay<InstanceInfo> {
     public static final String MODEL_DATA = "instance";

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/TabLayout.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/TabLayout.java
@@ -12,7 +12,6 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBar.Tab;
 import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/TermsOfService.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/TermsOfService.java
@@ -13,7 +13,6 @@ import android.widget.Toast;
 
 import com.loopj.android.http.JsonHttpResponseHandler;
 
-import org.apache.http.Header;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;
 import org.azavea.otm.LoginManager;
@@ -23,6 +22,8 @@ import org.azavea.otm.rest.RequestGenerator;
 import org.azavea.otm.rest.handlers.LoggingJsonHttpResponseHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import cz.msebera.android.httpclient.Header;
 
 public class TermsOfService extends FragmentActivity {
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeEditDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeEditDisplay.java
@@ -21,7 +21,6 @@ import android.widget.Toast;
 
 import com.loopj.android.http.JsonHttpResponseHandler;
 
-import org.apache.http.Header;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;
 import org.azavea.otm.R;
@@ -34,6 +33,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+
+import cz.msebera.android.httpclient.Header;
 
 public class TreeEditDisplay extends TreeDisplay {
     // Intent Request codes

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeInfoDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeInfoDisplay.java
@@ -17,7 +17,6 @@ import android.widget.Toast;
 
 import com.loopj.android.http.BinaryHttpResponseHandler;
 
-import org.apache.http.Header;
 import org.azavea.helpers.Logger;
 import org.azavea.otm.App;
 import org.azavea.otm.R;
@@ -27,6 +26,8 @@ import org.azavea.otm.fields.EcoField;
 import org.azavea.otm.fields.FieldGroup;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import cz.msebera.android.httpclient.Header;
 
 public class TreeInfoDisplay extends TreeDisplay {
     public final static int EDIT_REQUEST = 1;

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/UDFDateFragment.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/UDFDateFragment.java
@@ -9,7 +9,6 @@ import android.view.ViewGroup;
 import android.widget.DatePicker;
 
 import org.azavea.otm.R;
-import org.azavea.otm.fields.DateField;
 import org.json.JSONObject;
 
 import java.util.Calendar;


### PR DESCRIPTION
This also required switching from the built-in (and now deprecated) `org.apache.http` client to a better maintained fork, which is a transient dependency of Android-Async-Http.

I also removed some unused import statements while updating references to `org.apache.http`.

Connects to #259

Testing:
Ensure that application network functionality (connecting to the app server, getting tiles) continues to work as expected.
