### PR TITLE
Fix updating tiles after doing a search.

### DIFF
--- a/OpenTreeMap/build.gradle
+++ b/OpenTreeMap/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'com.atlassian.fugue:fugue:2.1.0'
     compile 'com.loopj.android:android-async-http:1.4.9'
-    compile 'info.guardianproject.netcipher:netcipher:1.2'
     compile 'com.rollbar:rollbar-android:0.1.3'
 
     // You must install or update the Support Repository through the SDK manager to use these dependencies

--- a/OpenTreeMap/src/main/java/org/azavea/map/FilterableTMSTileProvider.java
+++ b/OpenTreeMap/src/main/java/org/azavea/map/FilterableTMSTileProvider.java
@@ -22,11 +22,6 @@ public class FilterableTMSTileProvider extends TMSTileProvider {
         super(baseUrl, featureName);
     }
 
-    public FilterableTMSTileProvider(String baseUrl, String featureName, int opacity)
-            throws MalformedURLException {
-        super(baseUrl, featureName, opacity);
-    }
-
     @Override
     public URL getTileUrl(int x, int y, int zoom) {
         URL unfilteredUrl = super.getTileUrl(x, y, zoom);


### PR DESCRIPTION
Calling `TileOverlay.clearTileCache()` no longer seems to work on the version of Google Maps we are now using.
Neither did calling `TileOverlay.remove()`.

So instead now we remove every layer from the map and add them back after every search.

I also refactored the TMSTileProvider class to remove code supporting transparent overlays, as that is now built-in to the Google Maps API

Connects to #290