### PR TITLE
Fix map NPE

### DIFF
--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/MainMapFragment.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/MainMapFragment.java
@@ -276,12 +276,14 @@ public class MainMapFragment extends Fragment implements GoogleApiClient.Connect
     @Override
     public void onStart() {
         super.onStart();
+        mapView.onStart();
         mGoogleApiClient.connect();
     }
 
     @Override
     public void onStop() {
         super.onStop();
+        mapView.onStop();
         mGoogleApiClient.disconnect();
     }
 
@@ -484,7 +486,7 @@ public class MainMapFragment extends Fragment implements GoogleApiClient.Connect
                     LatLng latlng = new LatLng(loc.getLatitude(), loc.getLongitude());
                     App.getAppInstance().ensureInstanceLoaded(result -> {
                         LatLngBounds extent = App.getCurrentInstance().getExtent();
-                        if (extent.contains(latlng)) {
+                        if (extent.contains(latlng) && mMap != null) {
                             mMap.moveCamera(CameraUpdateFactory
                                     .newLatLngZoom(latlng, STREET_ZOOM_LEVEL));
                         }

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/MainMapFragment.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/MainMapFragment.java
@@ -186,7 +186,14 @@ public class MainMapFragment extends Fragment implements GoogleApiClient.Connect
      * *****************************************************
      */
     @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mapView.onCreate(savedInstanceState);
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
         this.setHasOptionsMenu(true);
 
         final View view = inflater.inflate(R.layout.main_map, container, false);
@@ -195,7 +202,6 @@ public class MainMapFragment extends Fragment implements GoogleApiClient.Connect
         MapHelper.checkGooglePlay(getActivity());
 
         mapView = (MapView) view.findViewById(R.id.map);
-        mapView.onCreate(savedInstanceState);
 
         final ProgressDialog dialog = ProgressDialog.show(getActivity(), "",
                 "Loading Map Info...", true);


### PR DESCRIPTION
Rollbar registered the following error:
```
java.lang.NullPointerException: Attempt to invoke virtual method
'void com.google.android.gms.maps.GoogleMap.moveCamera(
    com.google.android.gms.maps.CameraUpdate)'
on a null object reference

at org.azavea.otm.ui.MainMapFragment.lambda$null$3
    (MainMapFragment.java:488)
```

It's not clear whether the null refers to the `CameraUpdate`
from the `CameraUpdateFactory` or to `mMap`, but I'm guessing `mMap`.

If that's the case, it's probably a race condition,
which explains why I can't reproduce it.

Following instructions in
[MapView](https://developers.google.com/android/reference/com/google/android/gms/maps/MapView)
to call `mapView` "on" methods required for the fragment lifecycle.

The instructions say to call `mapView.onCreate()` from the fragment
`onCreate`, but we're dependent on the view, so that has to be in
the fragment `onCreateView`. I don't know if that could be a source
of race condition.

Since we can't follow the lifecycle instructions for `onCreate`,
put up a defensive null check.

--

Connects to #294 