### PR TITLE
Refactor for Asynchronous control flow

### DIFF
--- a/OpenTreeMap/src/main/java/org/azavea/otm/App.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/App.java
@@ -248,15 +248,15 @@ public class App extends Application {
         private Callback callback;
         private InstanceInfo responseInstanceInfo;
 
-        public InstanceRefreshHandler(Callback callback) {
+        InstanceRefreshHandler(Callback callback) {
             this(new InstanceInfo(), callback);
         }
 
-        public InstanceRefreshHandler() {
+        InstanceRefreshHandler() {
             this(new InstanceInfo(), null);
         }
 
-        public InstanceRefreshHandler(InstanceInfo instanceInfo, Callback callback) {
+        InstanceRefreshHandler(InstanceInfo instanceInfo, Callback callback) {
             super(instanceInfo);
             this.responseInstanceInfo = instanceInfo;
             this.callback = callback;
@@ -291,9 +291,10 @@ public class App extends Application {
 
         @Override
         public void failure(Throwable e, String message) {
-            Logger.error("Unable to Load Instance: " + responseInstanceInfo.getName(), e);
-            Toast.makeText(appInstance, "Cannot load configured tree map.",
-                    Toast.LENGTH_LONG).show();
+            String errorMessage = appInstance.getString(R.string.cannot_load_instance) +
+                    responseInstanceInfo.getName();
+            Logger.error(errorMessage, e);
+            Toast.makeText(appInstance, errorMessage, Toast.LENGTH_LONG).show();
             handleCallback(false);
         }
 

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/MapHelper.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/MapHelper.java
@@ -10,7 +10,7 @@ import android.widget.ImageView;
 import android.widget.Toast;
 
 import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.maps.GoogleMap;
 import com.joelapenna.foursquared.widget.SegmentedButton;
 import com.loopj.android.http.BinaryHttpResponseHandler;
@@ -38,12 +38,12 @@ public class MapHelper {
     }
 
     public static void checkGooglePlay(Activity activity) {
-        int googlePlayStatus = GooglePlayServicesUtil.isGooglePlayServicesAvailable(activity);
+        GoogleApiAvailability google = GoogleApiAvailability.getInstance();
+        int googlePlayStatus = google.isGooglePlayServicesAvailable(activity);
         if (googlePlayStatus != ConnectionResult.SUCCESS) {
-            Dialog dialog = GooglePlayServicesUtil.getErrorDialog(googlePlayStatus, activity, 1);
+            Dialog dialog = google.getErrorDialog(activity, googlePlayStatus, 1);
             dialog.show();
         }
-
     }
 
     protected static BinaryHttpResponseHandler getPhotoDetailHandler(final Activity activity, final Plot plot) {

--- a/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeEditDisplay.java
+++ b/OpenTreeMap/src/main/java/org/azavea/otm/ui/TreeEditDisplay.java
@@ -352,7 +352,7 @@ public class TreeEditDisplay extends TreeDisplay {
         setResultOk(updatedPlot);
 
         // Updating may have changed the georev
-        App.getCurrentInstance().setGeoRevId(plot.getUpdatedGeoRev());
+        App.getCurrentInstance().setGeoRevId(updatedPlot.getUpdatedGeoRev());
 
         finish();
     }

--- a/OpenTreeMap/src/main/res/values/strings.xml
+++ b/OpenTreeMap/src/main/res/values/strings.xml
@@ -128,6 +128,8 @@
     <string name="instance_switcher_request_failed">Failed to load tree maps</string>
     <string name="filter_instances_hint">Filter tree maps…</string>
     <string name="instances_failed">Could not get tree maps</string>
+    <string name="cannot_load_instance">Unable to load tree map: </string>
+    <string name="map_failed">Unable to setup map; Google Play Store might not be setup correctly"</string>
     <string name="perms_add_tree_fail">Adding trees is not available to all users</string>
     <string name="perms_edit_tree_fail">Editing a tree\'s details is not available to all users</string>
     <string name="perms_add_tree_photo_fail">Adding tree photos is not available to all users</string>


### PR DESCRIPTION
Rollbar registered the following error:
```
java.lang.NullPointerException: Attempt to invoke virtual method
'void com.google.android.gms.maps.GoogleMap.moveCamera(
    com.google.android.gms.maps.CameraUpdate)'
on a null object reference

at org.azavea.otm.ui.MainMapFragment.lambda$null$3
    (MainMapFragment.java:488)
```

It's probably a race condition.
Tame the asynchronous control flow to eliminate race conditions.

AFAIK, this fixes all race conditions except open question #1 below.
Unknown how many rollbar errors it will eliminate, but should
eliminate the original npe.

Refer to
* [MapView](https://developers.google.com/android/reference/com/google/android/gms/maps/MapView)
* [GoogleMap](https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap)
* [MapsInitializer](https://developers.google.com/android/reference/com/google/android/gms/maps/MapsInitializer)
* [GoogleApiAvailability](https://developers.google.com/android/reference/com/google/android/gms/common/GoogleApiAvailability)
* [Fragment Life Cycle](https://developer.android.com/guide/components/fragments.html)

Changes:

- Use jDeferred to synchronize between asynchronous flows
- Move most initialization from onCreateView to `onActivityCreated`
- Move google api connect, map fetch, and add mode cancel to `onStart`
- Update `MapHelper` to use current google availability api

Open questions:

1. Need a way to manage the `MapHelper` google api dialog to determine
   whether the play store services problem gets resolved,
   and fail catastrophically if it doesn't.
2. Need a way to test missing play store services without wrecking my phone.
3. Fails to fix # 297, clearing the filter repositions the camera
4. Probably shouldn't create new `Deferred` objects if they
   already exist, but haven't noticed any negative effects of doing so
5. I don't know enough about the tile cache to be sure when it needs
   to be cleared.

--

Connects to #294